### PR TITLE
Fix parallel rng

### DIFF
--- a/src/bgmCompare_sampler.cpp
+++ b/src/bgmCompare_sampler.cpp
@@ -63,7 +63,7 @@ List impute_missing_data_for_graphical_model(
     const arma::imat& missing_data_indices,
     const arma::uvec& is_ordinal_variable,
     const arma::ivec& baseline_category,
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 ) {
   const int num_variables = observations.n_cols;
   const int num_missings = missing_data_indices.n_rows;
@@ -234,7 +234,7 @@ double find_reasonable_initial_step_size(
     const double main_alpha,
     const double main_beta,
     const double target_acceptance,
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 ) {
   arma::vec theta = vectorize_model_parameters(
     main_effects, pairwise_effects, inclusion_indicator, main_effect_indices,
@@ -350,7 +350,7 @@ SamplerResult update_parameters_with_nuts(
     HMCAdaptationController& adapt,
     const bool learn_mass_matrix,
     const bool selection,
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 ) {
   arma::vec current_state = vectorize_model_parameters(
     main_effects, pairwise_effects, inclusion_indicator,
@@ -613,7 +613,7 @@ void gibbs_update_step_for_graphical_model_parameters (
     const int num_groups,
     const arma::imat group_indices,
     double difference_scale,
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 ) {
 
   SamplerResult result = update_parameters_with_nuts(
@@ -670,7 +670,7 @@ Rcpp::List run_gibbs_sampler_for_bgmCompare(
     const arma::imat& group_indices,//new
     const arma::imat& interaction_index_matrix,//new
     arma::mat inclusion_probability,//new
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 ) {
   // --- Setup: dimensions and storage structures
   const int num_variables = observations.n_cols;

--- a/src/bgmCompare_sampler.h
+++ b/src/bgmCompare_sampler.h
@@ -1,7 +1,7 @@
 #pragma once
-#include <dqrng.h>
-#include <xoshiro.h>
 #include <RcppArmadillo.h>
+
+struct SafeRNG;
 
 Rcpp::List run_gibbs_sampler_for_bgmCompare(
     int chain_id,
@@ -35,5 +35,5 @@ Rcpp::List run_gibbs_sampler_for_bgmCompare(
     const arma::imat& group_indices,//new
     const arma::imat& interaction_index_matrix,//new
     arma::mat inclusion_probability,
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 );

--- a/src/bgm_helper.h
+++ b/src/bgm_helper.h
@@ -50,7 +50,7 @@ inline void initialise_graph(
     const arma::mat& incl_prob,
     arma::mat&  rest,
     const arma::imat& X,
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 ) {
   int V = indicator.n_rows;
   for (int i = 0; i < V-1; ++i) {

--- a/src/bgm_sampler.cpp
+++ b/src/bgm_sampler.cpp
@@ -50,7 +50,7 @@ void impute_missing_values_for_graphical_model (
     const arma::uvec& is_ordinal_variable,
     const arma::ivec& reference_category,
     arma::imat& sufficient_pairwise,
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 ) {
   const int num_variables = observations.n_cols;
   const int num_missings = missing_index.n_rows;
@@ -193,7 +193,7 @@ double find_reasonable_initial_step_size(
     const double interaction_scale,
     const double target_acceptance,
     const arma::imat& sufficient_pairwise,
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 ) {
   arma::vec theta = vectorize_model_parameters(
     main_effects, pairwise_effects, inclusion_indicator,
@@ -278,7 +278,7 @@ void update_main_effects_with_metropolis (
     arma::mat& proposal_sd_main,
     RWMAdaptationController& adapter,
     const int iteration,
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 ) {
   const int num_vars = observations.n_cols;
   arma::umat index_mask_main = arma::ones<arma::umat>(proposal_sd_main.n_rows, proposal_sd_main.n_cols);
@@ -381,7 +381,7 @@ void update_pairwise_effects_with_metropolis (
     const arma::ivec& reference_category,
     const int iteration,
     const arma::imat& sufficient_pairwise,
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 ) {
   arma::mat accept_prob_pairwise = arma::zeros<arma::mat>(num_variables, num_variables);
   arma::umat index_mask_pairwise = arma::zeros<arma::umat>(num_variables, num_variables);
@@ -478,7 +478,7 @@ void update_parameters_with_hmc(
     HMCAdaptationController& adapt,
     const bool learn_mass_matrix,
     const bool selection,
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 ) {
   arma::vec current_state = vectorize_model_parameters(
     main_effects, pairwise_effects, inclusion_indicator,
@@ -587,7 +587,7 @@ SamplerResult update_parameters_with_nuts(
     HMCAdaptationController& adapt,
     const bool learn_mass_matrix,
     const bool selection,
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 ) {
   arma::vec current_state = vectorize_model_parameters(
     main_effects, pairwise_effects, inclusion_indicator,
@@ -668,7 +668,7 @@ void tune_pairwise_proposal_sd(
     const arma::imat& sufficient_pairwise,
     int iteration,
     const WarmupSchedule& sched,
-    dqrng::xoshiro256plus& rng,
+    SafeRNG& rng,
     double target_accept = 0.44,
     double rm_decay = 0.75
 )
@@ -762,7 +762,7 @@ void update_indicator_interaction_pair_with_metropolis (
     const arma::uvec& is_ordinal_variable,
     const arma::ivec& reference_category,
     const arma::imat& sufficient_pairwise,
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 ) {
   for (int cntr = 0; cntr < num_interactions; cntr++) {
     const int variable1 = index(cntr, 1);
@@ -912,7 +912,7 @@ void gibbs_update_step_for_graphical_model_parameters (
     arma::ivec& treedepth_samples,
     arma::ivec& divergent_samples,
     arma::vec& energy_samples,
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 ) {
 
   // Step 0: Initialise random graph structure when edge_selection = TRUE
@@ -1071,7 +1071,7 @@ Rcpp::List run_gibbs_sampler_for_bgm(
     const int hmc_num_leapfrogs,
     const int nuts_max_depth,
     const bool learn_mass_matrix,
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 ) {
   // --- Setup: dimensions and storage structures
   const int num_variables = observations.n_cols;
@@ -1176,7 +1176,8 @@ Rcpp::List run_gibbs_sampler_for_bgm(
   for (int iteration = 0; iteration < total_iter; iteration++) {
     if (iteration % print_every == 0) {
       tbb::mutex::scoped_lock lock(get_print_mutex());
-      Rcpp::Rcout
+      std::cout
+      // Rcpp::Rcout
       << "[bgm] chain " << chain_id
       << " iteration " << iteration
       << " / " << total_iter

--- a/src/bgm_sampler.h
+++ b/src/bgm_sampler.h
@@ -1,7 +1,8 @@
 #pragma once
-#include <dqrng.h>
-#include <xoshiro.h>
 #include <RcppArmadillo.h>
+
+// forward declaration
+struct SafeRNG;
 
 Rcpp::List run_gibbs_sampler_for_bgm(
     int chain_id,
@@ -33,5 +34,5 @@ Rcpp::List run_gibbs_sampler_for_bgm(
     const int hmc_num_leapfrogs,
     const int nuts_max_depth,
     const bool learn_mass_matrix,
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 );

--- a/src/gibbs_functions_edge_prior.cpp
+++ b/src/gibbs_functions_edge_prior.cpp
@@ -33,7 +33,7 @@ arma::uvec table_cpp(arma::uvec x) {
 arma::mat add_row_col_block_prob_matrix(arma::mat X,
                                             double beta_alpha,
                                             double beta_beta,
-                                            dqrng::xoshiro256plus& rng) {
+                                            SafeRNG& rng) {
   arma::uword dim = X.n_rows;
   arma::mat Y(dim+1,dim+1,arma::fill::zeros);
 
@@ -159,7 +159,7 @@ inline void update_sumG(double &sumG,
 // Sample the cluster assignment in sample_block_allocations_mfm_sbm()
 // ----------------------------------------------------------------------------|
 arma::uword sample_cluster(arma::vec cluster_prob,
-                           dqrng::xoshiro256plus& rng) {
+                           SafeRNG& rng) {
   arma::vec cum_prob = arma::cumsum(cluster_prob);
   double u = runif(rng) * arma::max(cum_prob);
 
@@ -182,7 +182,7 @@ arma::uvec block_allocations_mfm_sbm(arma::uvec cluster_assign,
                                         arma::uword dirichlet_alpha,
                                         double beta_bernoulli_alpha,
                                         double beta_bernoulli_beta,
-                                        dqrng::xoshiro256plus& rng) {
+                                        SafeRNG& rng) {
   arma::uword old;
   arma::uword cluster;
   arma::uword no_clusters;
@@ -320,7 +320,7 @@ arma::mat block_probs_mfm_sbm(arma::uvec cluster_assign,
                                   arma::uword no_variables,
                                   double beta_bernoulli_alpha,
                                   double beta_bernoulli_beta,
-                                  dqrng::xoshiro256plus& rng) {
+                                  SafeRNG& rng) {
 
   arma::uvec cluster_size = table_cpp(cluster_assign);
   arma::uword no_clusters = cluster_size.n_elem;

--- a/src/gibbs_functions_edge_prior.h
+++ b/src/gibbs_functions_edge_prior.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "rng_utils.h"
 #include <RcppArmadillo.h>
+struct SafeRNG;
+
 
 // ----------------------------------------------------------------------------|
 // Compute partition coefficient for the MFM - SBM
@@ -22,7 +23,7 @@ arma::uvec block_allocations_mfm_sbm(arma::uvec cluster_assign,
                                                 arma::uword dirichlet_alpha,
                                                 double beta_bernoulli_alpha,
                                                 double beta_bernoulli_beta,
-                                                dqrng::xoshiro256plus& rng);
+                                                SafeRNG& rng);
 
 // ----------------------------------------------------------------------------|
 // Sample the block parameters for the MFM - SBM
@@ -32,4 +33,4 @@ arma::mat block_probs_mfm_sbm(arma::uvec cluster_assign,
                                         arma::uword no_variables,
                                         double beta_bernoulli_alpha,
                                         double beta_bernoulli_beta,
-                                        dqrng::xoshiro256plus& rng);
+                                        SafeRNG& rng);

--- a/src/mcmc_hmc.cpp
+++ b/src/mcmc_hmc.cpp
@@ -15,7 +15,7 @@ SamplerResult hmc_sampler(
     const std::function<arma::vec(const arma::vec&)>& grad,
     const int num_leapfrogs,
     const arma::vec& inv_mass_diag,
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 ) {
   arma::vec theta = init_theta;
   arma::vec init_r = arma::sqrt(1.0 / inv_mass_diag) % arma_rnorm_vec(rng, theta.n_elem);

--- a/src/mcmc_hmc.h
+++ b/src/mcmc_hmc.h
@@ -3,9 +3,7 @@
 #include <RcppArmadillo.h>
 #include <functional>
 #include "mcmc_utils.h"
-#include "rng_utils.h"
-
-
+struct SafeRNG;
 
 SamplerResult hmc_sampler(
     const arma::vec& init_theta,
@@ -14,5 +12,5 @@ SamplerResult hmc_sampler(
     const std::function<arma::vec(const arma::vec&)>& grad,
     const int num_leapfrogs,
     const arma::vec& inv_mass_diag,
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 );

--- a/src/mcmc_nuts.cpp
+++ b/src/mcmc_nuts.cpp
@@ -77,7 +77,7 @@ BuildTreeResult build_tree(
     const double kin0,
     Memoizer& memo,
     const arma::vec& inv_mass_diag,
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 ) {
   constexpr double Delta_max = 1000.0;
 
@@ -188,7 +188,7 @@ SamplerResult nuts_sampler(
     const std::function<double(const arma::vec&)>& log_post,
     const std::function<arma::vec(const arma::vec&)>& grad,
     const arma::vec& inv_mass_diag,
-    dqrng::xoshiro256plus& rng,
+    SafeRNG& rng,
     int max_depth
 ) {
   // Here memo is created locally; terminates at end of nuts_sampler() call

--- a/src/mcmc_nuts.h
+++ b/src/mcmc_nuts.h
@@ -6,8 +6,7 @@
 #include "mcmc_leapfrog.h"
 #include "mcmc_memoization.h"
 #include "mcmc_utils.h"
-#include "rng_utils.h"
-
+struct SafeRNG;
 
 
 /**
@@ -54,5 +53,5 @@ SamplerResult nuts_sampler(const arma::vec& init_theta,
                            const std::function<double(const arma::vec&)>& log_post,
                            const std::function<arma::vec(const arma::vec&)>& grad,
                            const arma::vec& inv_mass_diag,
-                           dqrng::xoshiro256plus& rng,
+                           SafeRNG& rng,
                            int max_depth = 10);

--- a/src/mcmc_rwm.cpp
+++ b/src/mcmc_rwm.cpp
@@ -30,7 +30,7 @@ SamplerResult rwm_sampler(
     double current_state,
     double step_size,
     const std::function<double(double)>& log_post,
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 ) {
   double proposed_state = rnorm(rng, current_state, step_size);
   double log_accept = log_post(proposed_state) - log_post(current_state);

--- a/src/mcmc_rwm.h
+++ b/src/mcmc_rwm.h
@@ -4,7 +4,7 @@
 #include <cmath>
 #include <functional>
 #include "mcmc_utils.h"
-#include "rng_utils.h"
+struct SafeRNG;
 
 using namespace Rcpp;
 
@@ -12,5 +12,5 @@ SamplerResult rwm_sampler(
     double current_state,
     double step_size,
     const std::function<double(double)>& log_post,
-    dqrng::xoshiro256plus& rng
+    SafeRNG& rng
 );

--- a/src/mcmc_utils.cpp
+++ b/src/mcmc_utils.cpp
@@ -51,7 +51,7 @@ double heuristic_initial_step_size(
     const arma::vec& theta,
     const std::function<double(const arma::vec&)>& log_post,
     const std::function<arma::vec(const arma::vec&)>& grad,
-    dqrng::xoshiro256plus& rng,
+    SafeRNG& rng,
     double target_acceptance,
     double init_step,
     int max_attempts

--- a/src/mcmc_utils.h
+++ b/src/mcmc_utils.h
@@ -5,7 +5,7 @@
 #include <cmath>
 #include <functional>
 #include <memory>
-#include "rng_utils.h"
+struct SafeRNG;
 
 // (only if <algorithm> didn’t already provide it under C++17)
 #if __cplusplus < 201703L
@@ -216,7 +216,7 @@ double heuristic_initial_step_size(
     const arma::vec& theta,
     const std::function<double(const arma::vec&)>& log_post,
     const std::function<arma::vec(const arma::vec&)>& grad,
-    dqrng::xoshiro256plus& rng,
+    SafeRNG& rng,
     double target_acceptance = 0.625,
     double init_step = 1.0,
     int max_attempts = 20


### PR DESCRIPTION
tested with

```r
library(bgms)
x = Wenchuan[1:50, 1:5]
p = ncol(x)

samples1 = bgm(x, iter = 1000, nuts_max_depth = 10, cores = 4, chains = 4, seed = 1234)
samples2 = bgm(x, iter = 1000, nuts_max_depth = 10, cores = 4, chains = 4, seed = 1234)

print(all.equal(samples1$raw_samples$main,     samples2$raw_samples$main))
print(all.equal(samples1$raw_samples$pairwise, samples2$raw_samples$pairwise))
```
prints `TRUE` for both (on my machine).
